### PR TITLE
Override the current schedule

### DIFF
--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/OverrideDTO.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/OverrideDTO.java
@@ -1,0 +1,7 @@
+package nl.itvitae.rooster.scheduledday;
+
+import java.util.List;
+import java.util.Map;
+
+public record OverrideDTO(List<ScheduleddayDTO> successes, Map<ScheduleddayDTO, String> failures) {
+}

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/OverrideRequest.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/OverrideRequest.java
@@ -1,0 +1,4 @@
+package nl.itvitae.rooster.scheduledday;
+
+public record OverrideRequest(String date, int classroomId, boolean adaptWeekly) {
+}

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -33,7 +33,8 @@ public class ScheduleddayController {
     Scheduledday scheduledday = scheduleddayService.findById(id);
     LocalDate date = LocalDate.parse(overrideRequest.date());
     Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
-    if (scheduleddayRepository.existsByDateAndClassroom(date, classroom)) {
+    if (scheduleddayRepository.existsByDateAndClassroom(date, classroom)
+        || scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup())) {
       return ResponseEntity.badRequest().build();
     }
     return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom, overrideRequest.adaptWeekly()));

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -34,7 +34,7 @@ public class ScheduleddayController {
     LocalDate date = LocalDate.parse(overrideRequest.date());
     Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
     if (scheduleddayRepository.existsByDateAndClassroom(date, classroom)
-        || scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup())) {
+        || (!date.equals(scheduledday.getDate()) && scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup()))) {
       return ResponseEntity.badRequest().build();
     }
     return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom, overrideRequest.adaptWeekly()));

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -14,6 +14,7 @@ import java.time.LocalDate;
 @RequestMapping("api/v1/scheduleddays")
 public class ScheduleddayController {
 
+  private final ScheduleddayRepository scheduleddayRepository;
   private final ScheduleddayService scheduleddayService;
   private final ClassroomService classroomService;
 
@@ -32,6 +33,9 @@ public class ScheduleddayController {
     Scheduledday scheduledday = scheduleddayService.findById(id);
     LocalDate date = LocalDate.parse(overrideRequest.date());
     Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
+    if (scheduleddayRepository.existsByDateAndClassroom(date, classroom)) {
+      return ResponseEntity.badRequest().build();
+    }
     return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom, overrideRequest.adaptWeekly()));
   }
 }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -1,12 +1,12 @@
 package nl.itvitae.rooster.scheduledday;
 
 import lombok.AllArgsConstructor;
+import nl.itvitae.rooster.classroom.Classroom;
+import nl.itvitae.rooster.classroom.ClassroomService;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.CrossOrigin;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.web.bind.annotation.*;
+
+import java.time.LocalDate;
 
 @RestController
 @CrossOrigin("http://localhost:4200")
@@ -15,6 +15,7 @@ import org.springframework.web.bind.annotation.RestController;
 public class ScheduleddayController {
 
   private final ScheduleddayService scheduleddayService;
+  private final ClassroomService classroomService;
 
   @GetMapping
   public ResponseEntity<?> getAll() {
@@ -24,5 +25,13 @@ public class ScheduleddayController {
   @GetMapping("/month/{month}/{year}")
   public ResponseEntity<?> getAllByMonth(@PathVariable int month, @PathVariable int year){
     return ResponseEntity.ok(scheduleddayService.findAllByMonth(month, year).stream().map(ScheduleddayDTO::new).toList());
+  }
+
+  @PutMapping("/override/{id}")
+  public ResponseEntity<?> overrideScheduling(@PathVariable long id, @RequestBody OverrideRequest overrideRequest) {
+    Scheduledday scheduledday = scheduleddayService.findById(id);
+    LocalDate date = LocalDate.parse(overrideRequest.date());
+    Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
+    return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom, overrideRequest.adaptWeekly()));
   }
 }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -3,9 +3,11 @@ package nl.itvitae.rooster.scheduledday;
 import lombok.AllArgsConstructor;
 import nl.itvitae.rooster.classroom.Classroom;
 import nl.itvitae.rooster.classroom.ClassroomService;
+import nl.itvitae.rooster.freeday.FreeDayRepository;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import java.time.DayOfWeek;
 import java.time.LocalDate;
 
 @RestController
@@ -17,6 +19,7 @@ public class ScheduleddayController {
   private final ScheduleddayRepository scheduleddayRepository;
   private final ScheduleddayService scheduleddayService;
   private final ClassroomService classroomService;
+  private final FreeDayRepository freeDayRepository;
 
   @GetMapping
   public ResponseEntity<?> getAll() {
@@ -33,7 +36,8 @@ public class ScheduleddayController {
     Scheduledday scheduledday = scheduleddayService.findById(id);
     LocalDate date = LocalDate.parse(overrideRequest.date());
     Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
-    if (scheduleddayRepository.existsByDateAndClassroom(date, classroom)
+    if (date.getDayOfWeek().equals(DayOfWeek.SATURDAY) || date.getDayOfWeek().equals(DayOfWeek.SUNDAY)
+        || freeDayRepository.existsByDate(date) || scheduleddayRepository.existsByDateAndClassroom(date, classroom)
         || (!date.equals(scheduledday.getDate()) && scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup()))) {
       return ResponseEntity.badRequest().build();
     }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -9,6 +9,7 @@ import org.springframework.web.bind.annotation.*;
 
 import java.time.DayOfWeek;
 import java.time.LocalDate;
+import java.util.Optional;
 
 @RestController
 @CrossOrigin("http://localhost:4200")
@@ -35,12 +36,12 @@ public class ScheduleddayController {
   public ResponseEntity<?> overrideScheduling(@PathVariable long id, @RequestBody OverrideRequest overrideRequest) {
     Scheduledday scheduledday = scheduleddayService.findById(id);
     LocalDate date = LocalDate.parse(overrideRequest.date());
-    Classroom classroom = classroomService.getById(overrideRequest.classroomId()).get();
-    if (date.getDayOfWeek().equals(DayOfWeek.SATURDAY) || date.getDayOfWeek().equals(DayOfWeek.SUNDAY)
-        || freeDayRepository.existsByDate(date) || scheduleddayRepository.existsByDateAndClassroom(date, classroom)
+    Optional<Classroom> classroom = classroomService.getById(overrideRequest.classroomId());
+    if (classroom.isEmpty() || date.getDayOfWeek().equals(DayOfWeek.SATURDAY) || date.getDayOfWeek().equals(DayOfWeek.SUNDAY)
+        || freeDayRepository.existsByDate(date) || scheduleddayRepository.existsByDateAndClassroom(date, classroom.get())
         || (!date.equals(scheduledday.getDate()) && scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup()))) {
       return ResponseEntity.badRequest().build();
     }
-    return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom, overrideRequest.adaptWeekly()));
+    return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom.get(), overrideRequest.adaptWeekly()));
   }
 }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayRepository.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayRepository.java
@@ -2,6 +2,8 @@ package nl.itvitae.rooster.scheduledday;
 
 import java.time.LocalDate;
 import java.util.List;
+import java.util.Optional;
+
 import nl.itvitae.rooster.classroom.Classroom;
 import nl.itvitae.rooster.group.Group;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -11,4 +13,6 @@ public interface ScheduleddayRepository extends JpaRepository<Scheduledday, Long
   boolean existsByDateAndClassroom(LocalDate date, Classroom classroom);
 
   boolean existsByDateAndLessonGroup(LocalDate date, Group group);
+
+  Optional<Scheduledday> findByDateAndClassroom(LocalDate date, Classroom classroom);
 }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
@@ -51,15 +51,16 @@ public class ScheduleddayService {
 
     if (adaptWeekly) {
       oldDate = oldDate.plusWeeks(1);
+      LocalDate newDate = date.plusWeeks(1);
       while (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom)) {
         Scheduledday nextScheduledday = scheduleddayRepository.findByDateAndClassroom(oldDate, oldClassroom).get();
         if (nextScheduledday.getLesson().getGroup().getGroupNumber() == scheduledday.getLesson().getGroup().getGroupNumber()) {
-          LocalDate newDate = date.plusWeeks(1);
           nextScheduledday.setDate(newDate);
           nextScheduledday.setClassroom(classroom);
           scheduleddayRepository.save(nextScheduledday);
         }
         oldDate = oldDate.plusWeeks(1);
+        newDate = newDate.plusWeeks(1);
       }
     }
 

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
@@ -66,23 +66,36 @@ public class ScheduleddayService {
       oldDate = oldDate.plusWeeks(1);
       LocalDate newDate = date.plusWeeks(1);
       Group group = scheduledday.getLesson().getGroup();
-      while (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom)) {
-        Scheduledday nextScheduledday = scheduleddayRepository.findByDateAndClassroom(oldDate, oldClassroom).get();
-        //check if the nextScheduledday found is a scheduledday for the correct group
-        if (nextScheduledday.getLesson().getGroup().getGroupNumber() == group.getGroupNumber()) {
-          //try to override nextScheduledday, add to successes list if it can be done, add to failures map if it can't be done
-          try {
-            if (scheduleddayRepository.existsByDateAndClassroom(newDate, classroom)) {
-              throw new OverrideException(String.format("Classroom %d already in use on %s", classroom.getId(), newDate));
-            } else if (!newDate.equals(oldDate) && scheduleddayRepository.existsByDateAndLessonGroup(newDate, group)) {
-              throw new OverrideException(String.format("Group %d already has a lesson on %s", group.getGroupNumber(), newDate));
+
+      //continue checking as long as scheduling exists on this date and classroom or the date is a free day
+      while (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom) || freeDayRepository.existsByDate(oldDate)) {
+        if (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom)) {
+          Scheduledday nextScheduledday = scheduleddayRepository.findByDateAndClassroom(oldDate, oldClassroom).get();
+
+          //check if the nextScheduledday found is a scheduledday for the correct group
+          if (nextScheduledday.getLesson().getGroup().getGroupNumber() == group.getGroupNumber()) {
+
+            //if newDate is a free day, delete scheduling and add to successes list
+            if (freeDayRepository.existsByDate(newDate)) {
+              scheduleddayRepository.delete(nextScheduledday);
+              successes.add(new ScheduleddayDTO(nextScheduledday));
+            } else {
+
+              //try to override nextScheduledday, add to successes list if it can be done, add to failures map if it can't be done
+              try {
+                if (scheduleddayRepository.existsByDateAndClassroom(newDate, classroom)) {
+                  throw new OverrideException(String.format("Classroom %d already in use on %s", classroom.getId(), newDate));
+                } else if (!newDate.equals(oldDate) && scheduleddayRepository.existsByDateAndLessonGroup(newDate, group)) {
+                  throw new OverrideException(String.format("Group %d already has a lesson on %s", group.getGroupNumber(), newDate));
+                }
+                nextScheduledday.setDate(newDate);
+                nextScheduledday.setClassroom(classroom);
+                scheduleddayRepository.save(nextScheduledday);
+                successes.add(new ScheduleddayDTO(nextScheduledday));
+              } catch (OverrideException e) {
+                failures.put(new ScheduleddayDTO(nextScheduledday), e.getMessage());
+              }
             }
-            nextScheduledday.setDate(newDate);
-            nextScheduledday.setClassroom(classroom);
-            scheduleddayRepository.save(nextScheduledday);
-            successes.add(new ScheduleddayDTO(nextScheduledday));
-          } catch (OverrideException e) {
-            failures.put(new ScheduleddayDTO(nextScheduledday), e.getMessage());
           }
         }
         oldDate = oldDate.plusWeeks(1);

--- a/frontend/src/app/schedule/data.service.ts
+++ b/frontend/src/app/schedule/data.service.ts
@@ -1,5 +1,5 @@
 import { Injectable } from '@angular/core';
-import { HttpClient } from '@angular/common/http';
+import { HttpClient, HttpHeaders } from '@angular/common/http';
 import { Observable } from 'rxjs';
 
 @Injectable({
@@ -22,5 +22,12 @@ export class DataService {
   getFreeDaysByMonth(month: number, year: number): Observable<any> {
     const url = `${this.apiUrl}freedays/month/${month}/${year}`
     return this.http.get<any>(url);
+  }
+
+  override(id: number, data: any) {
+    const url = `${this.apiUrl}scheduleddays/override/${id}`;
+    return this.http.put<any>(url, data, {
+      headers: new HttpHeaders({ 'Content-type': 'application/json' }),
+    });
   }
 } 

--- a/frontend/src/app/schedule/override/override.component.css
+++ b/frontend/src/app/schedule/override/override.component.css
@@ -1,0 +1,4 @@
+input {
+  border-width: 1px;
+  border-color: black;
+}

--- a/frontend/src/app/schedule/override/override.component.html
+++ b/frontend/src/app/schedule/override/override.component.html
@@ -1,0 +1,15 @@
+<h1>Group {{ scheduledday.groupNumber }} {{ scheduledday.field }}</h1>
+<form [formGroup]="override" (ngSubmit)="onSubmit()">
+  <label for="date">Date: </label>
+  <input id="date" type="date" formControlName="date" required /><br />
+  <label for="classroom">Classroom: </label>
+  <input
+    id="classroom"
+    type="number"
+    formControlName="classroomId"
+    required
+  /><br />
+  <label for="adapt-weekly">Adapt Weekly: </label>
+  <input id="adapt-weekly" type="checkbox" formControlName="adaptWeekly" /><br />
+  <button type="submit" class="button-action">Submit</button>
+</form>

--- a/frontend/src/app/schedule/override/override.component.spec.ts
+++ b/frontend/src/app/schedule/override/override.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { OverrideComponent } from './override.component';
+
+describe('OverrideComponent', () => {
+  let component: OverrideComponent;
+  let fixture: ComponentFixture<OverrideComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [OverrideComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(OverrideComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/schedule/override/override.component.ts
+++ b/frontend/src/app/schedule/override/override.component.ts
@@ -1,0 +1,62 @@
+import { Component, Input } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { DataService } from '../data.service';
+import { CommonModule } from '@angular/common';
+
+@Component({
+  selector: 'app-override',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule],
+  templateUrl: './override.component.html',
+  styleUrl: './override.component.css',
+})
+export class OverrideComponent {
+  @Input() scheduledday: any;
+  @Input() date: string = '';
+  @Input() classroomId: number = 0;
+
+  override!: FormGroup;
+
+  constructor(private dataService: DataService) {}
+
+  ngOnInit() {
+    this.initializeForm();
+  }
+
+  ngOnChanges(changes: any) {
+    if (
+      (changes.scheduledday && !changes.scheduledday.firstChange) ||
+      (changes.date && !changes.date.firstChange) ||
+      (changes.classroomId && !changes.classroomId.firstChange)
+    ) {
+      this.initializeForm();
+    }
+  }
+
+  private initializeForm() {
+    this.override = new FormGroup({
+      date: new FormControl(this.date),
+      classroomId: new FormControl(this.classroomId),
+      adaptWeekly: new FormControl(false),
+    });
+  }
+
+  onSubmit() {
+    const formValue = this.override.value;
+    const data = {
+      date: formValue.date,
+      classroomId: formValue.classroomId,
+      adaptWeekly: formValue.adaptWeekly,
+    };
+    console.log(data);
+    this.dataService.override(this.scheduledday.id, data).subscribe(
+      (response) => {
+        console.log('Response:', response);
+        window.location.reload();
+      },
+      (error) => {
+        console.error('Error:', error);
+      }
+    );
+  }
+}

--- a/frontend/src/app/schedule/schedule.component.css
+++ b/frontend/src/app/schedule/schedule.component.css
@@ -1,0 +1,25 @@
+/* Define background colors for weekends, free days, and regular days */
+.bg-yellow { 
+  background-color: #ffff00; /* Free Day */
+}
+
+.bg-light-green { 
+  background-color: #b5e6a2; /* Weekend */
+}
+
+.bg-blue { 
+  background-color: #28A8EA; /* Regular Day */
+}
+
+.bg-white { 
+  background-color: white; /* Default for classrooms */
+}
+
+/** this makes the .modal visible */
+.sshow {
+    display: block;
+}
+/** this makes the element hidden/invisible */
+.hhidden {
+    display: none;
+}

--- a/frontend/src/app/schedule/schedule.component.html
+++ b/frontend/src/app/schedule/schedule.component.html
@@ -1,16 +1,48 @@
 <div class="mx-2">Currently viewing: {{ getMonthName(month) }} {{ year }}</div>
-<button (click)="decrementMonth()"  class="button-action">Previous Month</button>
-<button (click)="incrementMonth()"  class="button-action">Next Month</button>
+<button (click)="decrementMonth()" class="button-action">Previous Month</button>
+<button (click)="incrementMonth()" class="button-action">Next Month</button>
 <table class="w-full">
   <tr>
     <th>Date</th>
     <th *ngFor="let number of TOTAL_CLASSROOMS">Classroom {{ number }}</th>
   </tr>
   <tr class="text-center border-2" *ngFor="let day of days">
-    <td [ngClass]="day.isFreeDay ? 'bg-[#ffff00]':  (day.isWeekend ? 'bg-[#b5e6a2]': 'bg-[#28A8EA]')" style="width: 5%;">{{ day.id }}/{{ month }}/{{ year }}</td>
-    <td *ngFor="let number of TOTAL_CLASSROOMS" [ngClass]="day.isFreeDay ? 'bg-[#ffff00]':  (day.isWeekend ? 'bg-[#b5e6a2]': 'bg-white')">
-      <div *ngFor="let item of data">
+    <td
+      [ngClass]="
+        day.isFreeDay
+          ? 'bg-yellow'
+          : day.isWeekend
+          ? 'bg-light-green'
+          : 'bg-blue'
+      "
+      style="width: 5%"
+    >
+      {{ day.id }}/{{ month }}/{{ year }}
+    </td>
+    <td
+      *ngFor="let number of TOTAL_CLASSROOMS"
+      [ngClass]="
+        day.isFreeDay
+          ? 'bg-yellow'
+          : day.isWeekend
+          ? 'bg-light-green'
+          : 'bg-white'
+      "
+      (dragover)="onDragOver($event)"
+      (drop)="onDrop($event, day, number)"
+    >
+      <div
+        *ngFor="let item of data"
+        draggable="true"
+        (dragstart)="onDragStart($event, item)"
+      >
         <app-scheduled-day [item]="item" [day]="day.id" [classroom]="number" />
+        <app-modal id="override-{{ item.id }}" class="hhidden">
+          <ng-container *ngIf="selectedModal && selectedModal === item.id">
+            <app-override [scheduledday]="item" [date]="destinationdate" [classroomId]="destinationclassroom"></app-override>
+            <button (click)="closeModal('override-' + item.id)">Close</button>
+          </ng-container>
+        </app-modal>
       </div>
     </td>
   </tr>

--- a/frontend/src/app/schedule/schedule.component.ts
+++ b/frontend/src/app/schedule/schedule.component.ts
@@ -2,16 +2,22 @@ import { CommonModule } from '@angular/common';
 import { Component } from '@angular/core';
 import { DataService } from './data.service';
 import { ScheduledDayComponent } from '../scheduled-day/scheduled-day.component';
+import { ModalComponent } from '../modal/modal.component';
+import { OverrideComponent } from './override/override.component';
 
 @Component({
   selector: 'app-schedule',
   standalone: true,
-  imports: [CommonModule, ScheduledDayComponent],
+  imports: [
+    CommonModule,
+    ScheduledDayComponent,
+    ModalComponent,
+    OverrideComponent,
+  ],
   templateUrl: './schedule.component.html',
   styleUrl: './schedule.component.css',
 })
 export class ScheduleComponent {
-
   data: Scheduledday[] = [];
   freeDays: FreeDay[] = [];
 
@@ -20,11 +26,15 @@ export class ScheduleComponent {
 
   days: Day[] = this.daysInMonth(this.year, this.month);
 
+  selectedModal: any = null;
+  destinationdate: string = '';
+  destinationclassroom: number = 0;
+
   TOTAL_CLASSROOMS: number[] = Array(6)
     .fill(0)
     .map((_, index) => index + 1);
 
-  daysInMonth(year: number, month: number): Day[] {    
+  daysInMonth(year: number, month: number): Day[] {
     const array = Array(new Date(year, month, 0).getDate())
       .fill(0)
       .map((_, index) => index + 1);
@@ -46,8 +56,10 @@ export class ScheduleComponent {
   }
 
   checkIfFreeDay(year: number, month: number, day: number) {
-    const fday = new Date(year, month -1, day);    
-    return !!this.freeDays.find((freeDay) => freeDay.date.getDate() == fday.getDate());
+    const fday = new Date(year, month - 1, day);
+    return !!this.freeDays.find(
+      (freeDay) => freeDay.date.getDate() == fday.getDate()
+    );
   }
 
   getMonthName(monthNumber: number): string {
@@ -80,22 +92,67 @@ export class ScheduleComponent {
   constructor(private dataService: DataService) {}
 
   ngOnInit(): void {
+    this.dataService
+      .getScheduledDaysByMonth(this.month, this.year)
+      .subscribe((response: any[]) => {
+        this.data = response;
+        this.data.map((item) => (item.date = new Date(item.date)));
+      });
 
-    
     this.dataService
-    .getScheduledDaysByMonth(this.month, this.year)
-    .subscribe((response: any[]) => {
-      this.data = response;
-      this.data.map((item) => (item.date = new Date(item.date)));
-    });
-    
-    this.dataService
-    .getFreeDaysByMonth(this.month, this.year)
-    .subscribe((response: any[]) => {
-      this.freeDays = response;
-      this.freeDays.map((item) => (item.date = new Date(item.date)));
-      this.days = this.daysInMonth(this.year, this.month);
-    });
+      .getFreeDaysByMonth(this.month, this.year)
+      .subscribe((response: any[]) => {
+        this.freeDays = response;
+        this.freeDays.map((item) => (item.date = new Date(item.date)));
+        this.days = this.daysInMonth(this.year, this.month);
+      });
+  }
+
+  onDragStart(event: DragEvent, draggedObject: Scheduledday) {
+    const index = this.data.findIndex((l) => l.id === draggedObject.id);
+    event?.dataTransfer?.setData('text', index.toString());
+  }
+
+  onDragOver(event: DragEvent) {
+    event.preventDefault();
+  }
+
+  onDrop(event: DragEvent, day: Day, classroom: number) {
+
+    const indexOfItemBeingDragged = Number(
+      event?.dataTransfer?.getData('text')
+    );
+    if (typeof indexOfItemBeingDragged !== 'number') {
+      return;
+    }
+    const draggedObject = this.data[indexOfItemBeingDragged];
+    if (!day.isFreeDay && !day.isWeekend) {
+      
+    console.log(this.month);
+    console.log(day);
+      this.destinationdate = new Date(this.year, this.month-1, day.id+1).toISOString().split('T')[0];
+      console.log(this.destinationdate);
+      this.destinationclassroom = classroom;
+      this.selectedModal = draggedObject.id;
+      this.showModal('override-' + draggedObject.id);
+    }
+    event?.dataTransfer?.clearData?.();
+  }
+
+  showModal(name: string) {
+    let modal_t = document.getElementById(name);
+    if (modal_t !== null) {
+      modal_t.classList.remove('hhidden');
+      modal_t.classList.add('sshow');
+    }
+  }
+  closeModal(name: string) {
+    let modal_t = document.getElementById(name);
+    if (modal_t !== null) {
+      modal_t.classList.remove('sshow');
+      modal_t.classList.add('hhidden');
+      this.selectedModal = null;
+    }
   }
 }
 
@@ -106,7 +163,7 @@ export interface Scheduledday {
   groupNumber: number;
   groupColor: string;
   field: string;
-  teacher: string,
+  teacher: string;
 }
 
 interface Day {
@@ -120,4 +177,3 @@ interface FreeDay {
   date: Date;
   name: string;
 }
-

--- a/frontend/src/app/view-groups/add-group/add-group.component.ts
+++ b/frontend/src/app/view-groups/add-group/add-group.component.ts
@@ -32,7 +32,7 @@ export class AddGroupComponent {
     this.dataService.postGroup(data).subscribe(
       (response) => {
         console.log('Response:', response);
-        window.location.reload();
+        //window.location.reload();
       },
       (error) => {
         console.error('Error:', error);

--- a/frontend/src/app/view-groups/add-group/add-group.component.ts
+++ b/frontend/src/app/view-groups/add-group/add-group.component.ts
@@ -32,7 +32,7 @@ export class AddGroupComponent {
     this.dataService.postGroup(data).subscribe(
       (response) => {
         console.log('Response:', response);
-        //window.location.reload();
+        window.location.reload();
       },
       (error) => {
         console.error('Error:', error);


### PR DESCRIPTION
Schedule can be overridden by dragging a lesson to a date and classroom on the schedule view. The designated date and classroom will be passed on to the override modal, from which these can still be adapted if so desired, and a checkbox for weekly overrides can be checked. Upon submitting, this data is passed to the overrideScheduling endpoint, from where the lesson will be moved to the new date and/or classroom. There will then be a weekly check (if this was desired) to keep overriding this lesson if possible.