### PR TITLE
Edit groups

### DIFF
--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
@@ -31,16 +31,15 @@ public class GroupController {
 
   @PostMapping("/new")
   public ResponseEntity<?> addGroup(@RequestBody GroupRequest request, UriComponentsBuilder ucb) {
-
+    if (request.weeksPhase1() < 1 || request.weeksPhase2() < 1 || request.weeksPhase3() < 1) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Amount of weeks needs to be greater than 0");
+    }
     if (groupRepository.findByGroupNumber(request.groupNumber()).isPresent()) {
       return ResponseEntity.status(HttpStatus.CONFLICT)
           .body("Group with number " + request.groupNumber() + " already exists.");
     }
     if (groupService.checkSimilarColor(request.color())) {
       return ResponseEntity.status(HttpStatus.CONFLICT).body("Color is too similar to color of other group.");
-    }
-    if (request.weeksPhase1() < 1 || request.weeksPhase2() < 1 || request.weeksPhase3() < 1) {
-      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Amount of weeks needs to be greater than 0");
     }
     final Field field = fieldService.getById(request.field());
     final LocalDate startDate = LocalDate.parse(request.startDate());
@@ -54,9 +53,13 @@ public class GroupController {
 
   @PutMapping("/{number}/edit")
   public ResponseEntity<?> editGroup(@PathVariable int number, @RequestBody GroupRequest request) {
+    if (request.weeksPhase1() < 1 || request.weeksPhase2() < 1 || request.weeksPhase3() < 1) {
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Amount of weeks needs to be greater than 0");
+    }
+
     Optional<Group> existingGroup = groupRepository.findByGroupNumber(number);
     if (existingGroup.isEmpty()) {
-      return ResponseEntity.badRequest().build();
+      return ResponseEntity.status(HttpStatus.BAD_REQUEST).body("Group " + number + " does not exist");
     } else {
       final Group group = groupService.editGroup(existingGroup.get(), request.groupNumber(), request.color(),
           request.numberOfStudents(), fieldService.getById(request.field()), LocalDate.parse(request.startDate()),

--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
@@ -49,6 +49,20 @@ public class GroupController {
     return ResponseEntity.created(locationOfGroup).body(group);
   }
 
+  @PutMapping("/{number}/edit")
+  public ResponseEntity<?> editGroup(@PathVariable int number, @RequestBody GroupRequest request) {
+    Optional<Group> existingGroup = groupRepository.findByGroupNumber(number);
+    if (existingGroup.isEmpty()) {
+      return ResponseEntity.badRequest().build();
+    } else {
+      final Group group = groupService.editGroup(existingGroup.get(), request.groupNumber(), request.color(),
+          request.numberOfStudents(), fieldService.getById(request.field()), LocalDate.parse(request.startDate()),
+          request.weeksPhase1(), request.weeksPhase2(), request.weeksPhase3());
+      groupService.rescheduleGroup(group, LocalDate.now());
+      return ResponseEntity.ok(GroupDTO.of(group));
+    }
+  }
+
   @PutMapping("/{number}/reschedule")
   public ResponseEntity<?> rescheduleGroup(@PathVariable int number) {
     Optional<Group> group = groupRepository.findByGroupNumber(number);

--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupController.java
@@ -34,7 +34,8 @@ public class GroupController {
       UriComponentsBuilder ucb) {
 
     if (groupRepository.findByGroupNumber(request.groupNumber()).isPresent()) {
-      return ResponseEntity.status(HttpStatus.CONFLICT).body("Group with number " + request.groupNumber() + " already exists.");
+      return ResponseEntity.status(HttpStatus.CONFLICT)
+          .body("Group with number " + request.groupNumber() + " already exists.");
     }
     if (groupService.checkSimilarColor(request.color())) {
       return ResponseEntity.status(HttpStatus.CONFLICT).body("Color is too similar to color of other group.");
@@ -78,6 +79,7 @@ public class GroupController {
   @PutMapping("/{number}/addVacation")
   public ResponseEntity<?> addVacation(@PathVariable int number, @RequestBody VacationRequest request) {
     Group group = groupRepository.findByGroupNumber(number).get();
-    return ResponseEntity.ok(GroupDTO.of(groupService.addVacation(group, LocalDate.parse(request.startDate()), request.weeks())));
+    return ResponseEntity.ok(GroupDTO.of(groupService.addVacation(
+        group, LocalDate.parse(request.startDate()), request.weeks())));
   }
 }

--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupDTO.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupDTO.java
@@ -26,7 +26,8 @@ public record GroupDTO(
     String[] vacations = new String[group.getVacations().size()];
     for (int i = 0; i < vacations.length; i++) {
       Vacation vacation = group.getVacations().get(i);
-      vacations[i] = String.format("%d weeks vacation starting %s", vacation.getWeeks(), vacation.getStartDate().toString());
+      vacations[i] = String.format(
+          "%d weeks vacation starting %s", vacation.getWeeks(), vacation.getStartDate().toString());
     }
     return new GroupDTO(groupNumber, color, numberOfStudents, field,
         startDate, weeksPhase1, weeksPhase2, weeksPhase3, daysPhase1, daysPhase2, daysPhase3, teachers, vacations);

--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupRequest.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupRequest.java
@@ -1,4 +1,5 @@
 package nl.itvitae.rooster.group;
 
-public record GroupRequest(int groupNumber, String color, int numberOfStudents, long field, String startDate, int weeksPhase1, int weeksPhase2, int weeksPhase3) {
+public record GroupRequest(int groupNumber, String color, int numberOfStudents, long field, String startDate,
+                           int weeksPhase1, int weeksPhase2, int weeksPhase3) {
 }

--- a/backend/src/main/java/nl/itvitae/rooster/group/GroupService.java
+++ b/backend/src/main/java/nl/itvitae/rooster/group/GroupService.java
@@ -46,6 +46,19 @@ public class GroupService {
             weeksPhase3));
   }
 
+  public Group editGroup(Group group, int groupNumber, String color, int numberOfStudents, Field field,
+                         LocalDate startDate, int weeksPhase1, int weeksPhase2, int weeksPhase3) {
+    group.setGroupNumber(groupNumber);
+    group.setColor(color);
+    group.setNumberOfStudents(numberOfStudents);
+    group.setField(field);
+    group.setStartDate(startDate);
+    group.setWeeksPhase1(weeksPhase1);
+    group.setWeeksPhase2(weeksPhase2);
+    group.setWeeksPhase3(weeksPhase3);
+    return groupRepository.save(group);
+  }
+
   public Group addVacation(Group group, LocalDate startDate, int weeks) {
     Vacation vacation = new Vacation(startDate, weeks, group);
     vacationRepository.save(vacation);
@@ -75,15 +88,18 @@ public class GroupService {
   }
 
   public void scheduleReturnDay(Group group, long classroomId, DayOfWeek dayOfWeek) {
-    LocalDate date = group.getStartDate().minusDays(group.getStartDate().getDayOfWeek().getValue()).plusDays(dayOfWeek.getValue());
+    LocalDate date = group.getStartDate()
+        .minusDays(group.getStartDate().getDayOfWeek().getValue()).plusDays(dayOfWeek.getValue());
     for (int i = 0; i < (group.getWeeksPhase1() + group.getWeeksPhase2() + group.getWeeksPhase3()); i++) {
       if (freeDayRepository.existsByDate(date)) continue;
-      scheduleddayService.addScheduledday(date.plusWeeks(i), classroomService.getById(classroomId).get(), lessonService.createLesson(group, true));
+      scheduleddayService.addScheduledday(date.plusWeeks(i), classroomService.getById(classroomId).get(),
+          lessonService.createLesson(group, true));
     }
   }
 
   public Group rescheduleReturnDay (Group group) {
-    group.setStartDate(group.getStartDate().plusWeeks(group.getWeeksPhase1() + group.getWeeksPhase2() + group.getWeeksPhase3()));
+    group.setStartDate(group.getStartDate().plusWeeks(
+        group.getWeeksPhase1() + group.getWeeksPhase2() + group.getWeeksPhase3()));
 
     List<Scheduledday> scheduledreturndays = scheduleddayRepository.findByLessonGroup(group);
     Scheduledday latestScheduledreturnday = scheduledreturndays.get(0);
@@ -93,7 +109,8 @@ public class GroupService {
       }
     }
     
-    scheduleReturnDay(group, latestScheduledreturnday.getClassroom().getId(), latestScheduledreturnday.getDate().getDayOfWeek());
+    scheduleReturnDay(group, latestScheduledreturnday.getClassroom().getId(),
+        latestScheduledreturnday.getDate().getDayOfWeek());
     return group;
   }
 
@@ -124,15 +141,18 @@ public class GroupService {
       }
     }
     LocalDate previousStartDate = startDate;
-    LocalDate nextStartDate = schedulePeriod(Math.max(group.getWeeksPhase1() - weeks, 0), group.getField().getDaysPhase1(), startDate, group);
+    LocalDate nextStartDate = schedulePeriod(Math.max(group.getWeeksPhase1() - weeks, 0),
+        group.getField().getDaysPhase1(), startDate, group);
     if (nextStartDate.equals(previousStartDate)) {
-      nextStartDate = schedulePeriod(Math.max(group.getWeeksPhase2() - (weeks - group.getWeeksPhase1()), 0), group.getField().getDaysPhase2(), nextStartDate, group);
+      nextStartDate = schedulePeriod(Math.max(group.getWeeksPhase2() - (weeks - group.getWeeksPhase1()), 0),
+          group.getField().getDaysPhase2(), nextStartDate, group);
     } else {
       previousStartDate = nextStartDate;
       nextStartDate = schedulePeriod(group.getWeeksPhase2(), group.getField().getDaysPhase2(), nextStartDate, group);
     }
     if (nextStartDate.equals(previousStartDate)) {
-      schedulePeriod(Math.max(group.getWeeksPhase3() - (weeks - group.getWeeksPhase1() - group.getWeeksPhase2()), 0), group.getField().getDaysPhase3(), nextStartDate, group);
+      schedulePeriod(Math.max(group.getWeeksPhase3() - (weeks - group.getWeeksPhase1() - group.getWeeksPhase2()), 0),
+          group.getField().getDaysPhase3(), nextStartDate, group);
     } else {
       schedulePeriod(group.getWeeksPhase3(), group.getField().getDaysPhase3(), nextStartDate, group);
     }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayController.java
@@ -66,9 +66,11 @@ public class ScheduleddayController {
       return ResponseEntity.badRequest().body("Day cannot be scheduled on weekends on freedays");
     }
     if (scheduleddayRepository.existsByDateAndClassroom(date, classroom.get())
-        || (!date.equals(scheduledday.getDate()) && scheduleddayRepository.existsByDateAndLessonGroup(date, scheduledday.getLesson().getGroup()))) {
+        || (!date.equals(scheduledday.getDate()) && scheduleddayRepository.existsByDateAndLessonGroup(
+            date, scheduledday.getLesson().getGroup()))) {
       return ResponseEntity.badRequest().body("Day + Classroom are already scheduled");
     }
-    return ResponseEntity.ok(scheduleddayService.overrideScheduling(scheduledday, date, classroom.get(), overrideRequest.adaptWeekly()));
+    return ResponseEntity.ok(scheduleddayService.overrideScheduling(
+        scheduledday, date, classroom.get(), overrideRequest.adaptWeekly()));
   }
 }

--- a/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
+++ b/backend/src/main/java/nl/itvitae/rooster/scheduledday/ScheduleddayService.java
@@ -61,7 +61,8 @@ public class ScheduleddayService {
     return scheduleddayRepository.save(scheduledday);
   }
 
-  public OverrideDTO overrideScheduling(Scheduledday scheduledday, LocalDate date, Classroom classroom, boolean adaptWeekly) {
+  public OverrideDTO overrideScheduling(
+      Scheduledday scheduledday, LocalDate date, Classroom classroom, boolean adaptWeekly) {
 
     //create successes list and failures map for the OverrideDTO
     List<ScheduleddayDTO> successes = new ArrayList<>();
@@ -84,7 +85,8 @@ public class ScheduleddayService {
       Group group = scheduledday.getLesson().getGroup();
 
       //continue checking as long as scheduling exists on this date and classroom or the date is a free day
-      while (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom) || freeDayRepository.existsByDate(oldDate)) {
+      while (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom)
+          || freeDayRepository.existsByDate(oldDate)) {
         if (scheduleddayRepository.existsByDateAndClassroom(oldDate, oldClassroom)) {
           Scheduledday nextScheduledday = scheduleddayRepository.findByDateAndClassroom(oldDate, oldClassroom).get();
 
@@ -97,12 +99,15 @@ public class ScheduleddayService {
               successes.add(new ScheduleddayDTO(nextScheduledday));
             } else {
 
-              //try to override nextScheduledday, add to successes list if it can be done, add to failures map if it can't be done
+              //try to override nextScheduledday, add to successes if it can be done or to failures if it can't be done
               try {
                 if (scheduleddayRepository.existsByDateAndClassroom(newDate, classroom)) {
-                  throw new OverrideException(String.format("Classroom %d already in use on %s", classroom.getId(), newDate));
-                } else if (!newDate.equals(oldDate) && scheduleddayRepository.existsByDateAndLessonGroup(newDate, group)) {
-                  throw new OverrideException(String.format("Group %d already has a lesson on %s", group.getGroupNumber(), newDate));
+                  throw new OverrideException(
+                      String.format("Classroom %d already in use on %s", classroom.getId(), newDate));
+                } else if (!newDate.equals(oldDate)
+                    && scheduleddayRepository.existsByDateAndLessonGroup(newDate, group)) {
+                  throw new OverrideException(
+                      String.format("Group %d already has a lesson on %s", group.getGroupNumber(), newDate));
                 }
                 nextScheduledday.setDate(newDate);
                 nextScheduledday.setClassroom(classroom);

--- a/backend/src/main/java/nl/itvitae/rooster/teacher/TeacherController.java
+++ b/backend/src/main/java/nl/itvitae/rooster/teacher/TeacherController.java
@@ -25,7 +25,8 @@ public class TeacherController {
 
   @PostMapping("/new")
   public ResponseEntity<?> addTeacher(@RequestBody TeacherRequest request, UriComponentsBuilder ucb) {
-    final Teacher teacher = teacherService.addTeacher(request.name(), request.teachesPracticum(), request.availability(), request.maxDaysPerWeek());
+    final Teacher teacher = teacherService.addTeacher(
+        request.name(), request.teachesPracticum(), request.availability(), request.maxDaysPerWeek());
     URI locationOfTeacher = ucb.path("/api/v1/teachers").buildAndExpand(teacher.getId()).toUri();
     return ResponseEntity.created(locationOfTeacher).body(teacher);
   }
@@ -42,7 +43,8 @@ public class TeacherController {
 
   @PutMapping("/edit/{id}")
   public ResponseEntity<TeacherDTO> setAvailability(@PathVariable long id, @RequestBody AvailabilityRequest request) {
-    return ResponseEntity.ok(TeacherDTO.of(teacherService.setAvailability(id, request.availability(), request.maxDaysPerWeek())));
+    return ResponseEntity.ok(TeacherDTO.of(
+        teacherService.setAvailability(id, request.availability(), request.maxDaysPerWeek())));
   }
 
 }

--- a/frontend/src/app/free-days/free-days.component.css
+++ b/frontend/src/app/free-days/free-days.component.css
@@ -1,0 +1,5 @@
+#add-free-day-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}

--- a/frontend/src/app/free-days/free-days.component.html
+++ b/frontend/src/app/free-days/free-days.component.html
@@ -1,10 +1,12 @@
 <h1>Free Days</h1>
-<button (click)="showModal()" class="button-action">Add Free Day</button>
+<button (click)="showModal()" class="button-action" id="add-free-day-button">
+  Add Free Day
+</button>
 
 <br />
 <app-modal id="add-free-days" class="hhidden">
   <app-add-free-days [fields]="fields"></app-add-free-days>
-  <button (click)="closeModal()"  class="button-action">Close</button>
+  <button (click)="closeModal()" class="button-action">Close</button>
 </app-modal>
 
 <div *ngFor="let freeDay of freeDays">
@@ -13,6 +15,6 @@
   </ng-container>
   <ng-template #showDeleted>
     {{ freeDay.date }} - {{ freeDay.name }}
-    <button (click)="remove(freeDay.id)" >🗑</button></ng-template
+    <button (click)="remove(freeDay.id)">🗑</button></ng-template
   >
 </div>

--- a/frontend/src/app/view-fields/edit-field/edit-field.component.ts
+++ b/frontend/src/app/view-fields/edit-field/edit-field.component.ts
@@ -26,7 +26,7 @@ export class EditFieldComponent {
   }
 
   ngOnChanges(changes: any) {
-    if (changes.teacher && !changes.teacher.firstChange) {
+    if (changes.field && !changes.field.firstChange) {
       this.initializeForm();
     }
   }

--- a/frontend/src/app/view-fields/view-fields.component.css
+++ b/frontend/src/app/view-fields/view-fields.component.css
@@ -1,0 +1,5 @@
+#add-field-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}

--- a/frontend/src/app/view-fields/view-fields.component.html
+++ b/frontend/src/app/view-fields/view-fields.component.html
@@ -1,23 +1,32 @@
 <h1>Fields</h1>
 <div *ngFor="let field of fields">
-  <p>{{ field.name }}</p>
-  <p>Phase 1: {{ field.daysPhase1 }} days per week</p>
-  <p>Phase 2: {{ field.daysPhase2 }} days per week</p>
-  <p>Phase 2: {{ field.daysPhase3 }} days per week</p>
-  <button class="button-action" (click)="showModal('edit-field-' + field.name)">
-    Edit
-  </button>
-  <app-modal id="edit-field-{{ field.name }}" class="hhidden">
-    <app-edit-field [field]="field"></app-edit-field>
+  <div>
+    <p>{{ field.name }}</p>
+    <p>Phase 1: {{ field.daysPhase1 }} days per week</p>
+    <p>Phase 2: {{ field.daysPhase2 }} days per week</p>
+    <p>Phase 2: {{ field.daysPhase3 }} days per week</p>
     <button
-      (click)="closeModal('edit-field-' + field.name)"
       class="button-action"
+      (click)="showModal('edit-field-' + field.name)"
     >
-      Close
+      Edit
     </button>
-  </app-modal>
+    <app-modal id="edit-field-{{ field.name }}" class="hhidden">
+      <app-edit-field [field]="field"></app-edit-field>
+      <button
+        (click)="closeModal('edit-field-' + field.name)"
+        class="button-action"
+      >
+        Close
+      </button>
+    </app-modal>
+  </div><br />
 </div>
-<button class="button-action" (click)="showModal('add-field')">
+<button
+  (click)="showModal('add-field')"
+  class="button-action"
+  id="add-field-button"
+>
   Add Field
 </button>
 

--- a/frontend/src/app/view-groups/data.service.ts
+++ b/frontend/src/app/view-groups/data.service.ts
@@ -25,22 +25,24 @@ export class DataService {
     });
   }
 
+  putGroup(groupNumber: number, data: any): Observable<any> {
+    return this.http.put<any>(
+      this.apiUrlGroups + '/' + groupNumber + '/edit', data, {
+        headers: new HttpHeaders({ 'Content-type': 'application/json' }),
+      });
+  }
+
   rescheduleGroup(groupNumber: number): Observable<any> {
     return this.http.put<any>(
-      this.apiUrlGroups + '/' + groupNumber + '/reschedule',
-      {
+      this.apiUrlGroups + '/' + groupNumber + '/reschedule',{
         headers: new HttpHeaders({ 'Content-type': 'application/json' }),
-      }
-    );
+      });
   }
 
   addVacation(groupNumber: number, data: any): Observable<any> {
     return this.http.put<any>(
-      this.apiUrlGroups + '/' + groupNumber + '/addVacation',
-      data,
-      {
+      this.apiUrlGroups + '/' + groupNumber + '/addVacation', data, {
         headers: new HttpHeaders({ 'Content-type': 'application/json' }),
-      }
-    );
+      });
   }
 }

--- a/frontend/src/app/view-groups/edit-group/edit-group.component.html
+++ b/frontend/src/app/view-groups/edit-group/edit-group.component.html
@@ -1,0 +1,69 @@
+<h1>Edit Group {{ group.groupNumber }}</h1>
+<form [formGroup]="editGroup" (ngSubmit)="onSubmit()">
+  <label for="color">Color: </label>
+  <input id="color" type="color" formControlName="color" required /><br />
+  <label for="number-of-students">Number of students: </label>
+  <input
+    id="number-of-students"
+    type="number"
+    formControlName="numberOfStudents"
+    required
+  /><br />
+  <label for="field">Field: </label>
+  <select id="field" formControlName="field" required>
+    <option [ngValue]="null" disabled>Select Field</option>
+    <option *ngFor="let field of fields" [ngValue]="field.id">
+      {{ field.name }}
+    </option></select
+  ><br />
+  <label for="start-date">Start Date: </label>
+  <input
+    id="start-date"
+    type="date"
+    formControlName="startDate"
+    required
+  /><br />
+  <label for="weeks-phase-1">Weeks Phase 1: </label>
+  <input
+    id="weeks-phase-1"
+    type="number"
+    formControlName="weeksPhase1"
+    required
+  /><br />
+  <label for="weeks-phase-2">Weeks Phase 2: </label>
+  <input
+    id="weeks-phase-2"
+    type="number"
+    formControlName="weeksPhase2"
+    required
+  /><br />
+  <label for="weeks-phase-3">Weeks Phase 2: </label>
+  <input
+    id="weeks-phase-3"
+    type="number"
+    formControlName="weeksPhase3"
+    required
+  /><br />
+
+  <button
+    [ngClass]="editGroup.valid ? 'button-action' : 'button-incomplete'"
+    type="submit"
+    [disabled]="!editGroup.valid"
+  >
+    Submit
+  </button>
+</form>
+
+<app-modal id="feedback-edit-group-{{ group.groupNumber }}" class="hhidden">
+  <p>{{ this.feedbackMsg }}</p>
+  <button
+    class="button-action"
+    (click)="
+      this.feedbackMsg.startsWith('Error: ')
+        ? closeModal('feedback-edit-group-' + group.groupNumber)
+        : window.location.reload()
+    "
+  >
+    Close
+  </button>
+</app-modal>

--- a/frontend/src/app/view-groups/edit-group/edit-group.component.spec.ts
+++ b/frontend/src/app/view-groups/edit-group/edit-group.component.spec.ts
@@ -1,0 +1,23 @@
+import { ComponentFixture, TestBed } from '@angular/core/testing';
+
+import { EditGroupComponent } from './edit-group.component';
+
+describe('EditGroupComponent', () => {
+  let component: EditGroupComponent;
+  let fixture: ComponentFixture<EditGroupComponent>;
+
+  beforeEach(async () => {
+    await TestBed.configureTestingModule({
+      imports: [EditGroupComponent]
+    })
+    .compileComponents();
+
+    fixture = TestBed.createComponent(EditGroupComponent);
+    component = fixture.componentInstance;
+    fixture.detectChanges();
+  });
+
+  it('should create', () => {
+    expect(component).toBeTruthy();
+  });
+});

--- a/frontend/src/app/view-groups/edit-group/edit-group.component.ts
+++ b/frontend/src/app/view-groups/edit-group/edit-group.component.ts
@@ -1,0 +1,95 @@
+import { Component, Input } from '@angular/core';
+import { FormControl, FormGroup, ReactiveFormsModule } from '@angular/forms';
+import { DataService } from '../data.service';
+import { CommonModule } from '@angular/common';
+import { ModalComponent } from '../../modal/modal.component';
+
+@Component({
+  selector: 'app-edit-group',
+  standalone: true,
+  imports: [CommonModule, ReactiveFormsModule, ModalComponent],
+  templateUrl: './edit-group.component.html',
+  styleUrl: './edit-group.component.css',
+})
+export class EditGroupComponent {
+  feedbackMsg!: string;
+  window = window;
+
+  @Input() group: any;
+  @Input() fields: any[] = [];
+
+  editGroup!: FormGroup;
+
+  constructor(private dataService: DataService) {}
+
+  ngOnInit() {
+    this.initializeForm();
+  }
+
+  ngOnChanges(changes: any) {
+    if (changes.group && !changes.group.firstChange) {
+      this.initializeForm();
+    }
+  }
+
+  getField() {
+    const field = this.fields.filter(
+      (field) => field.name === this.group.field
+    );
+    return field[0].id;
+  }
+
+  private initializeForm() {
+    this.editGroup = new FormGroup({
+      color: new FormControl(this.group.color),
+      numberOfStudents: new FormControl(this.group.numberOfStudents),
+      field: new FormControl(this.getField()),
+      startDate: new FormControl(this.group.startDate),
+      weeksPhase1: new FormControl(this.group.weeksPhase1),
+      weeksPhase2: new FormControl(this.group.weeksPhase2),
+      weeksPhase3: new FormControl(this.group.weeksPhase3),
+    });
+  }
+
+  onSubmit() {
+    const formValue = this.editGroup.value;
+    const data = {
+      groupNumber: this.group.groupNumber,
+      color: formValue.color,
+      numberOfStudents: formValue.numberOfStudents,
+      field: formValue.field,
+      startDate: formValue.startDate,
+      weeksPhase1: formValue.weeksPhase1,
+      weeksPhase2: formValue.weeksPhase2,
+      weeksPhase3: formValue.weeksPhase3,
+    };
+    this.dataService.putGroup(this.group.groupNumber, data).subscribe(
+      (response) => {
+        console.log('Response:', response);
+        this.feedbackMsg = `Group ${response.groupNumber} succesfully edited`;
+        this.showModal('feedback-edit-group-' + this.group.groupNumber);
+      },
+      (error) => {
+        console.error('Error:', error);
+        this.feedbackMsg = `Error: ${error.error}`;
+        this.showModal('feedback-edit-group-' + this.group.groupNumber);
+      }
+    );
+  }
+
+  showModal(name: string) {
+    let modal_t = document.getElementById(name);
+    if (modal_t !== null) {
+      modal_t.classList.remove('hhidden');
+      modal_t.classList.add('sshow');
+    }
+  }
+
+  closeModal(name: string) {
+    let modal_t = document.getElementById(name);
+    if (modal_t !== null) {
+      modal_t.classList.remove('sshow');
+      modal_t.classList.add('hhidden');
+    }
+  }
+}

--- a/frontend/src/app/view-groups/view-groups.component.css
+++ b/frontend/src/app/view-groups/view-groups.component.css
@@ -1,3 +1,9 @@
 button {
   color: black;
 }
+
+#add-group-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}

--- a/frontend/src/app/view-groups/view-groups.component.html
+++ b/frontend/src/app/view-groups/view-groups.component.html
@@ -39,20 +39,27 @@
       Reschedule Group</button
     ><br />
     <div *ngIf="group.groupNumber != 0">
-      <button class="button-action" (click)="showModal('edit-group-' + group.groupNumber)">
+      <button
+        class="button-action"
+        (click)="showModal('edit-group-' + group.groupNumber)"
+      >
         Edit Group
       </button>
 
       <app-modal id="edit-group-{{ group.groupNumber }}" class="hhidden">
         <app-edit-group [group]="group" [fields]="fields"></app-edit-group>
-        <button (click)="closeModal('edit-group-' + group.groupNumber)" class="button-action">
+        <button
+          (click)="closeModal('edit-group-' + group.groupNumber)"
+          class="button-action"
+        >
           Close
         </button>
       </app-modal>
     </div>
   </div>
+  <br />
 </div>
-<button class="button-action" (click)="showModal('add-group')">
+<button id="add-group-button" class="button-action" (click)="showModal('add-group')">
   Add Group
 </button>
 

--- a/frontend/src/app/view-groups/view-groups.component.html
+++ b/frontend/src/app/view-groups/view-groups.component.html
@@ -38,6 +38,18 @@
     <button class="button-action" (click)="reschedule(group.groupNumber)">
       Reschedule Group</button
     ><br />
+    <div *ngIf="group.groupNumber != 0">
+      <button class="button-action" (click)="showModal('edit-group-' + group.groupNumber)">
+        Edit Group
+      </button>
+
+      <app-modal id="edit-group-{{ group.groupNumber }}" class="hhidden">
+        <app-edit-group [group]="group" [fields]="fields"></app-edit-group>
+        <button (click)="closeModal('edit-group-' + group.groupNumber)" class="button-action">
+          Close
+        </button>
+      </app-modal>
+    </div>
   </div>
 </div>
 <button class="button-action" (click)="showModal('add-group')">

--- a/frontend/src/app/view-groups/view-groups.component.html
+++ b/frontend/src/app/view-groups/view-groups.component.html
@@ -59,7 +59,11 @@
   </div>
   <br />
 </div>
-<button id="add-group-button" class="button-action" (click)="showModal('add-group')">
+<button
+  (click)="showModal('add-group')"
+  class="button-action"
+  id="add-group-button"
+>
   Add Group
 </button>
 

--- a/frontend/src/app/view-groups/view-groups.component.ts
+++ b/frontend/src/app/view-groups/view-groups.component.ts
@@ -4,6 +4,7 @@ import { ModalComponent } from '../modal/modal.component';
 import { AddGroupComponent } from './add-group/add-group.component';
 import { CommonModule } from '@angular/common';
 import { AddVacationComponent } from './add-vacation/add-vacation.component';
+import { EditGroupComponent } from './edit-group/edit-group.component';
 
 @Component({
   selector: 'app-view-groups',
@@ -13,6 +14,7 @@ import { AddVacationComponent } from './add-vacation/add-vacation.component';
     ModalComponent,
     AddGroupComponent,
     AddVacationComponent,
+    EditGroupComponent,
   ],
   templateUrl: './view-groups.component.html',
   styleUrl: './view-groups.component.css',

--- a/frontend/src/app/view-teachers/view-teachers.component.css
+++ b/frontend/src/app/view-teachers/view-teachers.component.css
@@ -1,0 +1,5 @@
+#add-teacher-button {
+  position: fixed;
+  bottom: 20px;
+  right: 20px;
+}

--- a/frontend/src/app/view-teachers/view-teachers.component.html
+++ b/frontend/src/app/view-teachers/view-teachers.component.html
@@ -1,42 +1,47 @@
 <h1>Teachers</h1>
 <div *ngFor="let teacher of teachers">
-  <h3>{{ teacher.name }}</h3>
+  <div>
+    <h3>{{ teacher.name }}</h3>
 
-  <h4>Availability:</h4>
-  <div *ngFor="let day of teacher.availability">
-    <p>- {{ day }}</p>
-  </div>
-  <p>max. {{ teacher.maxDaysPerWeek }} days per week</p>
-  <button
-    class="button-action"
-    (click)="showModal('set-availability-' + teacher.name)"
-  >
-    Set Availability
-  </button>
-  <app-modal id="set-availability-{{ teacher.name }}" class="hhidden">
-    <app-set-availability [teacher]="teacher"></app-set-availability>
-    <button (click)="closeModal('set-availability-' + teacher.name)">Close</button>
-  </app-modal>
+    <h4>Availability:</h4>
+    <div *ngFor="let day of teacher.availability">
+      <p>- {{ day }}</p>
+    </div>
+    <p>max. {{ teacher.maxDaysPerWeek }} days per week</p>
+    <button
+      class="button-action"
+      (click)="showModal('set-availability-' + teacher.name)"
+    >
+      Set Availability
+    </button>
+    <app-modal id="set-availability-{{ teacher.name }}" class="hhidden">
+      <app-set-availability [teacher]="teacher"></app-set-availability>
+      <button (click)="closeModal('set-availability-' + teacher.name)">
+        Close
+      </button>
+    </app-modal>
 
-  <h4>Groups:</h4>
-  <div *ngFor="let group of teacher.groups">
-    <p>- {{ group }}</p>
-  </div>
-  <button
-    (click)="showModal('add-group-' + teacher.name)"
-    class="button-action"
-  >
-    Add Group
-  </button>
-  <app-modal id="add-group-{{ teacher.name }}" class="hhidden">
-    <app-set-group [groups]="groups" [teacher]="teacher"></app-set-group>
-    <button (click)="closeModal('add-group-' + teacher.name)">Close</button>
-  </app-modal>
+    <h4>Groups:</h4>
+    <div *ngFor="let group of teacher.groups">
+      <p>- {{ group }}</p>
+    </div>
+    <button
+      (click)="showModal('add-group-' + teacher.name)"
+      class="button-action"
+    >
+      Add Group
+    </button>
+    <app-modal id="add-group-{{ teacher.name }}" class="hhidden">
+      <app-set-group [groups]="groups" [teacher]="teacher"></app-set-group>
+      <button (click)="closeModal('add-group-' + teacher.name)">Close</button>
+    </app-modal>
+  </div><br />
 </div>
 
 <button
   (click)="showModal('add-teacher')"
   class="button-action"
+  id="add-teacher-button"
 >
   Add Teacher
 </button>


### PR DESCRIPTION
Groups can now be edited through a modal similar to adding a group but with the info of the group to be edited filled in. Also made some layout changes to visually separate groups and ensure the add group button is always visible on the page. Then used this to change the add-buttons on the field-, teacher- and free day pages as well.